### PR TITLE
adds unicode support

### DIFF
--- a/cassandracsv/cassandracsv.py
+++ b/cassandracsv/cassandracsv.py
@@ -72,7 +72,7 @@ class CassandraCsv(object):
         else:
             _file = os.path.join(_path,"%s.csv" % self.filename)
 
-        with open(_file, 'w') as csvFile:
+        with open(_file, 'w', newline='', encoding='utf-8') as csvFile:
             writer = csv.writer(csvFile)
             writer.writerows(to_file)
 


### PR DESCRIPTION
To support saving Unicode  content to csv file, Require Python 3. 
NOTE:  NOT working with Python 2.7, which will be retired in Jan 2020 anyway.